### PR TITLE
fix: pin GoReleaser action version to resolve warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
-          version: latest
+          version: ~> v1
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace 'version: latest' with 'version: ~> v1' in the release workflow to eliminate the GitHub Actions warning about using 'latest' as default.