### PR TITLE
feat: add Git commit example templates

### DIFF
--- a/prompts/.gitignore
+++ b/prompts/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore

--- a/prompts/_git_commit_role.tmpl
+++ b/prompts/_git_commit_role.tmpl
@@ -1,0 +1,20 @@
+{{ define "_git_commit_role" }}
+You are an expert programmer specializing in writing clear, concise, and conventional Git commit messages.
+Commit message  must strictly follow the Conventional Commits specification.
+
+The final commit message you generate must be formatted exactly as follows:
+
+```
+<type>[optional scope]: A brief, imperative-tense summary of changes
+
+[Optional longer description, explaining the "why" of the change. Use dash points for clarity.]
+```
+{{ if .type -}}
+Use {{.type}} as a type.
+{{ end }}
+{{- if .scope -}}
+Use {{.scope}} as a scope.
+{{ else -}}
+Don't use any scope.
+{{ end }}
+{{ end }}

--- a/prompts/git_amend_commit.tmpl
+++ b/prompts/git_amend_commit.tmpl
@@ -1,0 +1,7 @@
+{{- /* Rewrite the commit message for the most recent commit */ -}}
+
+{{- template "_git_commit_role" . -}}
+
+Your task is to rewrite the commit message for the last commit.
+To understand the context, analyze the changes introduced in that commit using the command: `git show HEAD`
+Based on that analysis, update the last commit using a new, improved commit message.

--- a/prompts/git_squash_commit.tmpl
+++ b/prompts/git_squash_commit.tmpl
@@ -1,0 +1,19 @@
+{{- /* Squash commits since a start point and create a new, consolidated commit */ -}}
+
+{{- template "_git_commit_role" . -}}
+
+Your task is to squash all commits after `{{.start_commit}}` into a single new commit and apply a well-formed commit message.
+
+You must follow these steps precisely:
+
+Step 1: Analyze the changes and prepare the commit message.**
+First, analyze the combined diff of all the commits you are about to squash to understand the full scope of the changes doing `git diff {{.start_commit}}..HEAD`
+Based on your analysis of this diff, compose the perfect conventional commit message.
+
+Step 2: Perform the squash operation.
+Execute `git reset --soft {{.start_commit}}`. I will provide the commit message you just composed in the final step.
+
+Step 3: Create the new, squashed commit.
+Finally, use the commit message you composed in Step 1 to create the single, squashed commit doing `git commit -m ...`.
+
+After you have executed these steps, confirm that the operation is complete.

--- a/prompts/git_stage_commit.tmpl
+++ b/prompts/git_stage_commit.tmpl
@@ -1,0 +1,8 @@
+{{- /* Commit currently staged changes */ -}}
+
+{{- template "_git_commit_role" . -}}
+
+Your task is to commit all currently staged changes.
+To understand the context, analyze the staged code using the command: `git diff --staged`
+Based on that analysis, commit staged changes using a suitable commit message.
+


### PR DESCRIPTION
- Add reusable commit role template with conventional commits specification
- Add git_amend_commit template for rewriting commit messages
- Add git_squash_commit template for squashing commits with proper workflow
- Add git_stage_commit template for committing staged changes