### PR TITLE
fix: sort template variables in list output for consistent display

### DIFF
--- a/main.go
+++ b/main.go
@@ -356,6 +356,7 @@ func listTemplates(w io.Writer, promptsDir string, verbose bool) error {
 			mustFprintf(w, "%s\n", errorText(fmt.Sprintf("Error: %v", err)))
 		} else {
 			if len(args) > 0 {
+				sort.Strings(args)
 				mustFprintf(w, "  Variables: %s\n", highlightText(strings.Join(args, ", ")))
 			} else {
 				mustFprintf(w, "  Variables:\n")

--- a/main_test.go
+++ b/main_test.go
@@ -339,28 +339,28 @@ func (s *MainTestSuite) TestListTemplates() {
 			expectedLines: []string{
 				templateText("conditional_greeting.tmpl"),
 				"  Description: Conditional greeting template",
-				"  Variables: ", // Just check that Variables line exists, content may vary
+				"  Variables: name, show_extra_message",
 				templateText("greeting.tmpl"),
 				"  Description: Greeting standalone template with no partials",
-				"  Variables: ",
+				"  Variables: name",
 				templateText("greeting_with_partials.tmpl"),
 				"  Description: Greeting template with partial",
-				"  Variables: ",
+				"  Variables: name",
 				templateText("logical_operators.tmpl"),
 				"  Description: Template with logical operators (and/or) in if blocks",
-				"  Variables: ",
+				"  Variables: feature_enabled, feature_name, has_permission, is_admin, is_premium, is_trial, message, resource, show_error, show_warning, username",
 				templateText("multiple_partials.tmpl"),
 				"  Description: Template with multiple partials",
-				"  Variables: ",
+				"  Variables: author, description, name, title, version",
 				templateText("range_scalars.tmpl"),
 				"  Description: Template for testing range with JSON array of scalars",
-				"  Variables: ",
+				"  Variables: numbers, result, tags",
 				templateText("range_structs.tmpl"),
 				"  Description: Template for testing range with JSON array of structs",
-				"  Variables: ",
+				"  Variables: age, name, role, total, users",
 				templateText("with_object.tmpl"),
 				"  Description: Template for testing with + JSON object",
-				"  Variables: ",
+				"  Variables: config, debug, environment, name, version",
 			},
 			shouldError: false,
 		},
@@ -391,7 +391,7 @@ func (s *MainTestSuite) TestListTemplates() {
 				return
 			}
 
-			// For detailed mode, check structure but be flexible about variable content
+			// For detailed mode, check exact match including variables
 			lineIndex := 0
 			for _, expectedLine := range tt.expectedLines {
 				if lineIndex >= len(lines) {
@@ -399,9 +399,9 @@ func (s *MainTestSuite) TestListTemplates() {
 				}
 
 				if strings.HasPrefix(expectedLine, "  Variables: ") {
-					// Just check that the line starts with "  Variables: " and contains some content
-					assert.True(s.T(), strings.HasPrefix(lines[lineIndex], "  Variables: "),
-						"line %d should start with '  Variables: ', got: %s", lineIndex, lines[lineIndex])
+					// Remove ANSI color codes from the actual line for comparison
+					actualLine := removeANSIColors(lines[lineIndex])
+					assert.Equal(s.T(), expectedLine, actualLine, "line %d should match (variables are now sorted)", lineIndex)
 				} else {
 					assert.Equal(s.T(), expectedLine, lines[lineIndex], "line %d should match", lineIndex)
 				}

--- a/prompts_server_test.go
+++ b/prompts_server_test.go
@@ -193,7 +193,7 @@ func (s *PromptsServerTestSuite) TestServeStdioWithJSONArgumentParsing() {
 	ctx := context.Background()
 
 	// Create prompts server that will watch ./testdata directory
-	_, mcpClient, promptsClose := s.makePromptsServerAndClient(ctx, "./testdata", false)
+	_, mcpClient, promptsClose := s.makePromptsServerAndClient(ctx, "./testdata", true)
 	defer promptsClose()
 
 	// Test JSON boolean parsing
@@ -201,7 +201,7 @@ func (s *PromptsServerTestSuite) TestServeStdioWithJSONArgumentParsing() {
 	getReq.Params.Name = "conditional_greeting"
 	getReq.Params.Arguments = map[string]string{
 		"name":               "Alice",
-		"show_extra_message": "true", // JSON boolean becomes actual boolean
+		"show_extra_message": "false", // JSON boolean becomes actual boolean
 	}
 	getResult, err := mcpClient.GetPrompt(ctx, getReq)
 	require.NoError(s.T(), err, "GetPrompt failed")
@@ -211,7 +211,7 @@ func (s *PromptsServerTestSuite) TestServeStdioWithJSONArgumentParsing() {
 	require.True(s.T(), ok, "Expected TextContent")
 
 	actualContent := normalizeNewlines(content.Text)
-	expectedContent := "Hello Alice!\nThis is an extra message just for you.\nHave a good day."
+	expectedContent := "Hello Alice!\nHave a good day."
 	assert.Equal(s.T(), expectedContent, actualContent, "Unexpected content with JSON boolean parsing")
 }
 


### PR DESCRIPTION
- Sort variable names alphabetically in template listing
- Update test expectations to match sorted variable order
- Fix test case to use correct boolean value for expected output